### PR TITLE
Support using customized PrivateKey object from HSM provider in Crypto.java

### DIFF
--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Crypto.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Crypto.java
@@ -705,7 +705,7 @@ public class Crypto {
                 // Decrypt the private key with the specified password
 
                 InputDecryptorProvider pkcs8Prov = new JceOpenSSLPKCS8DecryptorProviderBuilder()
-                        .setProvider(BC_PROVIDER).build(pwd.toCharArray());
+                        .build(pwd.toCharArray());
 
                 PrivateKeyInfo privateKeyInfo = pKeyInfo.decryptPrivateKeyInfo(pkcs8Prov);
                 JcaPEMKeyConverter pemConverter = new JcaPEMKeyConverter();
@@ -1253,9 +1253,9 @@ public class Crypto {
 
             String signatureAlgorithm = getSignatureAlgorithm(caPrivateKey.getAlgorithm(), SHA256);
             ContentSigner caSigner = new JcaContentSignerBuilder(signatureAlgorithm)
-                    .setProvider(BC_PROVIDER).build(caPrivateKey);
+                    .build(caPrivateKey);
 
-            JcaX509CertificateConverter converter = new JcaX509CertificateConverter().setProvider(BC_PROVIDER);
+            JcaX509CertificateConverter converter = new JcaX509CertificateConverter();
             cert = converter.getCertificate(caBuilder.build(caSigner));
             ///CLOVER:OFF
         } catch (CertificateException ex) {
@@ -1296,7 +1296,7 @@ public class Crypto {
             Iterator<SignerInformation> it = signers.iterator();
 
             SignerInformationVerifier infoVerifier = new JcaSimpleSignerInfoVerifierBuilder()
-                    .setProvider(BC_PROVIDER).build(publicKey);
+                    .build(publicKey);
             while (it.hasNext()) {
                 SignerInformation signerInfo = it.next();
                 if (signerInfo.verify(infoVerifier)) {

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Crypto.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Crypto.java
@@ -230,9 +230,6 @@ public class Crypto {
             byte[] sig = signer.sign();
             return ybase64(sig);
             /// CLOVER:OFF
-        } catch (NoSuchProviderException e) {
-            LOG.error("sign: Caught NoSuchProviderException, check to make sure the provider is loaded correctly.");
-            throw new CryptoException(e);
         } catch (NoSuchAlgorithmException e) {
             LOG.error("sign: Caught NoSuchAlgorithmException, check to make sure the algorithm is supported by the provider.");
             throw new CryptoException(e);
@@ -261,9 +258,6 @@ public class Crypto {
             signer.initSign(key);
             signer.update(message);
             return signer.sign();
-        } catch (NoSuchProviderException e) {
-            LOG.error("sign: Caught NoSuchProviderException, check to make sure the provider is loaded correctly.");
-            throw new CryptoException(e);
         } catch (NoSuchAlgorithmException e) {
             LOG.error("sign: Caught NoSuchAlgorithmException, check to make sure the algorithm is supported by the provider.");
             throw new CryptoException(e);
@@ -306,9 +300,6 @@ public class Crypto {
             signer.update(utf8Bytes(message));
             return signer.verify(sig);
             ///CLOVER:OFF
-        } catch (NoSuchProviderException e) {
-            LOG.error("verify: Caught NoSuchProviderException, check to make sure the provider is loaded correctly.");
-            throw new CryptoException(e);
         } catch (InvalidKeyException e) {
             LOG.error("verify: Caught InvalidKeyException, invalid key type is being used.");
             throw new CryptoException(e);
@@ -351,9 +342,6 @@ public class Crypto {
             signer.initVerify(key);
             signer.update(message);
             return signer.verify(signature);
-        } catch (NoSuchProviderException e) {
-            LOG.error("verify: Caught NoSuchProviderException, check to make sure the provider is loaded correctly.");
-            throw new CryptoException(e);
         } catch (InvalidKeyException e) {
             LOG.error("verify: Caught InvalidKeyException, invalid key type is being used.");
             throw new CryptoException(e);

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Crypto.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Crypto.java
@@ -116,8 +116,7 @@ public class Crypto {
     public static final String SHA1 = "SHA1";
     public static final String SHA256 = "SHA256";
 
-    static final String ATHENZ_CRYPTO_BC_PROVIDER = "athenz.crypto.bc_provider";
-    private static final String BC_PROVIDER = "BC";
+    static final String ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER = "athenz.crypto.key_factory_provider";
 
     static final SecureRandom RANDOM;
     static {
@@ -136,7 +135,7 @@ public class Crypto {
     }
 
     private static String getProvider() {
-        return System.getProperty(ATHENZ_CRYPTO_BC_PROVIDER, "BC");
+        return System.getProperty(ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER, "BC");
     }
 
     private static String getECDSAAlgo() {
@@ -225,7 +224,7 @@ public class Crypto {
     public static String sign(String message, PrivateKey key, String digestAlgorithm) throws CryptoException {
         try {
             String signatureAlgorithm = getSignatureAlgorithm(key.getAlgorithm(), digestAlgorithm);
-            java.security.Signature signer = java.security.Signature.getInstance(signatureAlgorithm, BC_PROVIDER);
+            java.security.Signature signer = java.security.Signature.getInstance(signatureAlgorithm);
             signer.initSign(key);
             signer.update(utf8Bytes(message));
             byte[] sig = signer.sign();
@@ -258,7 +257,7 @@ public class Crypto {
     public static byte[] sign(byte[] message, PrivateKey key, String digestAlgorithm) throws CryptoException {
         try {
             String signatureAlgorithm = getSignatureAlgorithm(key.getAlgorithm(), digestAlgorithm);
-            java.security.Signature signer = java.security.Signature.getInstance(signatureAlgorithm, BC_PROVIDER);
+            java.security.Signature signer = java.security.Signature.getInstance(signatureAlgorithm);
             signer.initSign(key);
             signer.update(message);
             return signer.sign();
@@ -302,7 +301,7 @@ public class Crypto {
         try {
             byte [] sig = ybase64Decode(signature);
             String signatureAlgorithm = getSignatureAlgorithm(key.getAlgorithm(), digestAlgorithm);
-            java.security.Signature signer = java.security.Signature.getInstance(signatureAlgorithm, BC_PROVIDER);
+            java.security.Signature signer = java.security.Signature.getInstance(signatureAlgorithm);
             signer.initVerify(key);
             signer.update(utf8Bytes(message));
             return signer.verify(sig);
@@ -348,7 +347,7 @@ public class Crypto {
                                  String digestAlgorithm) throws CryptoException {
         try {
             String signatureAlgorithm = getSignatureAlgorithm(key.getAlgorithm(), digestAlgorithm);
-            java.security.Signature signer = java.security.Signature.getInstance(signatureAlgorithm, BC_PROVIDER);
+            java.security.Signature signer = java.security.Signature.getInstance(signatureAlgorithm);
             signer.initVerify(key);
             signer.update(message);
             return signer.verify(signature);
@@ -486,7 +485,6 @@ public class Crypto {
                 ///CLOVER:ON
                 try {
                     return new JcaX509CertificateConverter()
-                            .setProvider(BC_PROVIDER)
                             .getCertificate((X509CertificateHolder) pemObj);
                     ///CLOVER:OFF
                 } catch (CertificateException ex) {

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
@@ -330,8 +330,6 @@ public class CryptoTest {
         PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateParamsKey);
         assertNotNull(privateKey);
 
-        String signature = Crypto.sign(serviceToken, privateKey);
-
         System.setProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER, "C");
         assertThrows(CryptoException.class, () -> {
             Crypto.loadPublicKey(ecPublicParamsKey);

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
@@ -1195,7 +1195,12 @@ public class CryptoTest {
         publicKey = Crypto.loadPublicKey(rsaPublicKey);
         assertNotNull(publicKey);
 
-        assertFalse(Crypto.verify(serviceToken.getBytes(StandardCharsets.UTF_8), publicKey, signature, Crypto.SHA256));
+        try {
+            Crypto.verify(serviceToken.getBytes(StandardCharsets.UTF_8), publicKey, signature, Crypto.SHA256);
+            fail();
+        } catch (CryptoException ex) {
+            assertTrue(ex.getMessage().contains("SignatureException"));
+        }
     }
 
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
@@ -157,11 +157,11 @@ public class CryptoTest {
         });
         System.clearProperty(Crypto.ATHENZ_CRYPTO_ALGO_ECDSA);
 
-        System.setProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER, "C");
+        System.setProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER, "C");
         assertThrows(CryptoException.class, () -> {
             Crypto.extractPublicKey(privateKey);
         });
-        System.clearProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER);
+        System.clearProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER);
     }
 
     @Test
@@ -176,11 +176,11 @@ public class CryptoTest {
         });
         System.clearProperty(Crypto.ATHENZ_CRYPTO_ALGO_RSA);
 
-        System.setProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER, "C");
+        System.setProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER, "C");
         assertThrows(CryptoException.class, () -> {
             Crypto.extractPublicKey(privateKey);
         });
-        System.clearProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER);
+        System.clearProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER);
     }
 
     @Test
@@ -332,11 +332,11 @@ public class CryptoTest {
 
         String signature = Crypto.sign(serviceToken, privateKey);
 
-        System.setProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER, "C");
+        System.setProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER, "C");
         assertThrows(CryptoException.class, () -> {
             Crypto.loadPublicKey(ecPublicParamsKey);
         });
-        System.clearProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER);
+        System.clearProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER);
 
         System.setProperty(Crypto.ATHENZ_CRYPTO_ALGO_ECDSA, "TESTAlgo");
         assertThrows(CryptoException.class, () -> {


### PR DESCRIPTION
## Issue

The implement for signing is hard-coded to use the BouncyCastle provider. As the HSM provider that we are planing to use has its own implementation on the PrivateKey object, which is not compatible with BouncyCastle's implementation for creating signature. Signature cannot be created with HSM provider specific PrivateKey object.

## Fix

1. remove the hard-coded part in `Crypto.java`
1. leverage the provider selection to `java.security` file
1. rename system properties `athenz.crypto.bc_provider` to `athenz.crypto.key_factory_provider`
    - The system properties `athenz.crypto.bc_provider` is not documented or found in the example configuration files. We think that it is better to clarify the usage of this system property.