### PR TITLE
fix docker image

### DIFF
--- a/docker/util/athenz-mvn-base/Dockerfile
+++ b/docker/util/athenz-mvn-base/Dockerfile
@@ -37,10 +37,10 @@ WORKDIR /athenz
 COPY pom.xml .
 # cat pom.xml | grep "<module>.*</module>" | awk -F'[><]' '{ printf "COPY ./%s/pom.xml ./%s/pom.xml\n", $3, $3 }'
 COPY ./rdl/rdl-gen-athenz-server/pom.xml ./rdl/rdl-gen-athenz-server/pom.xml
-COPY ./rdl/rdl-gen-athenz-java-model/pom.xml ./rdl/rdl-gen-athenz-java-model/pom.xml
-COPY ./rdl/rdl-gen-athenz-java-client/pom.xml ./rdl/rdl-gen-athenz-java-client/pom.xml
 COPY ./rdl/rdl-gen-athenz-go-model/pom.xml ./rdl/rdl-gen-athenz-go-model/pom.xml
 COPY ./rdl/rdl-gen-athenz-go-client/pom.xml ./rdl/rdl-gen-athenz-go-client/pom.xml
+COPY ./rdl/rdl-gen-athenz-java-model/pom.xml ./rdl/rdl-gen-athenz-java-model/pom.xml
+COPY ./rdl/rdl-gen-athenz-java-client/pom.xml ./rdl/rdl-gen-athenz-java-client/pom.xml
 COPY ./core/zms/pom.xml ./core/zms/pom.xml
 COPY ./core/zts/pom.xml ./core/zts/pom.xml
 COPY ./libs/java/auth_core/pom.xml ./libs/java/auth_core/pom.xml

--- a/docker/zms/Dockerfile
+++ b/docker/zms/Dockerfile
@@ -28,9 +28,9 @@ WORKDIR /opt/athenz/zms
 COPY --from=builder /opt/athenz/zms .
 
 ENV JAVA_OPTS=''
-ENV CLASSPATH='lib/jars/*'
+ENV CLASSPATH='/opt/athenz/zms/lib/jars/*'
 ENV USER_CLASSPATH='/usr/lib/jars/*'
-ENV CONF_PATH='conf/zms_server'
+ENV CONF_PATH='/opt/athenz/zms/conf/zms_server'
 
 # ENV for passwords
 ENV ZMS_DB_ADMIN_PASS=''
@@ -38,21 +38,8 @@ ENV ZMS_RODB_ADMIN_PASS=''
 ENV ZMS_KEYSTORE_PASS=''
 ENV ZMS_TRUSTSTORE_PASS=''
 
-ENTRYPOINT ["sh", "-c", "eval $0 $@", "java"]
-CMD [ \
-  "${JAVA_OPTS}", \
-  "-classpath", "${CLASSPATH}:${USER_CLASSPATH}", \
-  "-Dathenz.prop_file=${CONF_PATH}/athenz.properties", \
-  "-Dathenz.zms.prop_file=${CONF_PATH}/zms.properties", \
-  "-Dlogback.configurationFile=${CONF_PATH}/logback.xml", \
-  # system properties for passwords
-  "-Dathenz.zms.jdbc_password=${ZMS_DB_ADMIN_PASS}", \
-  "-Dathenz.zms.jdbc_ro_password=${ZMS_RODB_ADMIN_PASS}", \
-  "-Dathenz.ssl_key_store_password=${ZMS_KEYSTORE_PASS}", \
-  "-Dathenz.ssl_trust_store_password=${ZMS_TRUSTSTORE_PASS}", \
-  # main class
-  "com.yahoo.athenz.container.AthenzJettyContainer" \
-]
+COPY ./docker/zms/docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 # ENV for healthcheck
 ENV ZMS_PORT='4443'

--- a/docker/zms/docker-entrypoint.sh
+++ b/docker/zms/docker-entrypoint.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+ZMS_STOP_TIMEOUT=${ZMS_STOP_TIMEOUT:-30}
+ZMS_CLASSPATH="${CLASSPATH}:${USER_CLASSPATH}"
+ZMS_BOOTSTRAP_CLASS="com.yahoo.athenz.container.AthenzJettyContainer"
+
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.prop_file=${CONF_PATH}/athenz.properties"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.zms.prop_file=${CONF_PATH}/zms.properties"
+JAVA_OPTS="${JAVA_OPTS} -Dlogback.configurationFile=${CONF_PATH}/logback.xml"
+# system properties for passwords
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.zms.jdbc_password=${ZMS_DB_ADMIN_PASS}"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.zms.jdbc_ro_password=${ZMS_RODB_ADMIN_PASS}"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.ssl_key_store_password=${ZMS_KEYSTORE_PASS}"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.ssl_trust_store_password=${ZMS_TRUSTSTORE_PASS}"
+
+### !!! P.S. cannot quote JAVA_OPTS !!!
+### reference: https://github.com/koalaman/shellcheck/wiki/SC2086
+java -classpath "${ZMS_CLASSPATH}" ${JAVA_OPTS} ${ZMS_BOOTSTRAP_CLASS} < /dev/null &
+PID=$!
+
+sleep 2;
+if ! kill -0 "${PID}" > /dev/null 2>&1; then
+    exit 1
+fi
+
+force_shutdown() {
+    echo 'Will forcefully stopping ZMS...'
+    kill -9 ${PID} >/dev/null 2>&1
+    echo 'Forcefully stopped ZMS success'
+    exit 1
+}
+shutdown() {
+    if [ -z ${PID} ]; then
+        echo 'ZMS is not running'
+        exit 1
+    else
+        if ! kill -0 ${PID} > /dev/null 2>&1; then
+            echo 'ZMS is not running'
+            exit 1
+        else
+            # start shutdown
+            echo 'Will stopping ZMS...'
+            kill ${PID}
+
+            # wait for shutdown
+            count=0
+            while [ -d "/proc/${PID}" ]; do
+                echo 'Shutdown is in progress... Please wait...'
+                sleep 1
+                count="$((count + 1))"
+    
+                if [ "${count}" = "${ZMS_STOP_TIMEOUT}" ]; then
+                    break
+                fi
+            done
+            if [ "${count}" != "${ZMS_STOP_TIMEOUT}" ]; then
+                echo 'Shutdown completed.'
+            fi
+
+            # if not success, force shutdown
+            if kill -0 ${PID} > /dev/null 2>&1; then
+                force_shutdown
+            fi
+        fi
+    fi
+
+    # confirm ZMS stopped
+    if ! kill -0 ${PID} > /dev/null 2>&1; then
+        exit 0
+    fi
+}
+
+# SIGINT
+trap shutdown 2
+
+# SIGTERM
+trap shutdown 15
+
+# wait
+wait ${PID}

--- a/docker/zts/Dockerfile
+++ b/docker/zts/Dockerfile
@@ -28,9 +28,9 @@ WORKDIR /opt/athenz/zts
 COPY --from=builder /opt/athenz/zts .
 
 ENV JAVA_OPTS=''
-ENV CLASSPATH='lib/jars/*'
+ENV CLASSPATH='/opt/athenz/zts/lib/jars/*'
 ENV USER_CLASSPATH='/usr/lib/jars/*'
-ENV CONF_PATH='conf/zts_server'
+ENV CONF_PATH='/opt/athenz/zts/conf/zts_server'
 
 # ENV for passwords
 ENV ZTS_DB_ADMIN_PASS=''
@@ -41,28 +41,8 @@ ENV ZTS_SIGNER_TRUSTSTORE_PASS=''
 ENV ZMS_CLIENT_KEYSTORE_PASS=''
 ENV ZMS_CLIENT_TRUSTSTORE_PASS=''
 
-ENTRYPOINT ["sh", "-c", "eval $0 $@", "java"]
-CMD [ \
-  "${JAVA_OPTS}", \
-  "-classpath", "${CLASSPATH}:${USER_CLASSPATH}", \
-  "-Dathenz.root_dir=.", \
-  "-Dathenz.zts.root_dir=.", \
-  "-Dathenz.prop_file=${CONF_PATH}/athenz.properties", \
-  "-Dathenz.zts.prop_file=${CONF_PATH}/zts.properties", \
-  "-Dlogback.configurationFile=${CONF_PATH}/logback.xml", \
-  # system properties for passwords
-  "-Dathenz.zts.cert_jdbc_password=${ZTS_DB_ADMIN_PASS}", \
-  "-Dathenz.ssl_key_store_password=${ZTS_KEYSTORE_PASS}", \
-  "-Dathenz.ssl_trust_store_password=${ZTS_TRUSTSTORE_PASS}", \
-  "-Dathenz.zts.keystore_signer.keystore_password=${ZTS_SIGNER_KEYSTORE_PASS}", \
-  "-Dathenz.zts.ssl_key_store_password=${ZTS_SIGNER_KEYSTORE_PASS}", \
-  "-Dathenz.zts.ssl_trust_store_password=${ZTS_SIGNER_TRUSTSTORE_PASS}", \
-  "-Djavax.net.ssl.trustStorePassword=${ZTS_SIGNER_TRUSTSTORE_PASS}", \
-  "-Dathenz.zms.client.keystore_password=${ZMS_CLIENT_KEYSTORE_PASS}", \
-  "-Dathenz.zms.client.truststore_password=${ZMS_CLIENT_TRUSTSTORE_PASS}", \
-  # main class
-  "com.yahoo.athenz.container.AthenzJettyContainer" \
-]
+COPY ./docker/zts/docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 # ENV for healthcheck
 ENV ZTS_PORT='8443'

--- a/docker/zts/docker-entrypoint.sh
+++ b/docker/zts/docker-entrypoint.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+ZTS_STOP_TIMEOUT=${ZTS_STOP_TIMEOUT:-30}
+ZTS_CLASSPATH="${CLASSPATH}:${USER_CLASSPATH}"
+ZTS_BOOTSTRAP_CLASS="com.yahoo.athenz.container.AthenzJettyContainer"
+
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.root_dir=."
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.zts.root_dir=."
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.prop_file=${CONF_PATH}/athenz.properties"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.zts.prop_file=${CONF_PATH}/zts.properties"
+JAVA_OPTS="${JAVA_OPTS} -Dlogback.configurationFile=${CONF_PATH}/logback.xml"
+# system properties for passwords
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.zts.cert_jdbc_password=${ZTS_DB_ADMIN_PASS}"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.ssl_key_store_password=${ZTS_KEYSTORE_PASS}"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.ssl_trust_store_password=${ZTS_TRUSTSTORE_PASS}"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.zts.keystore_signer.keystore_password=${ZTS_SIGNER_KEYSTORE_PASS}"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.zts.ssl_key_store_password=${ZTS_SIGNER_KEYSTORE_PASS}"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.zts.ssl_trust_store_password=${ZTS_SIGNER_TRUSTSTORE_PASS}"
+JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStorePassword=${ZTS_SIGNER_TRUSTSTORE_PASS}"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.zms.client.keystore_password=${ZMS_CLIENT_KEYSTORE_PASS}"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.zms.client.truststore_password=${ZMS_CLIENT_TRUSTSTORE_PASS}"
+
+### !!! P.S. cannot quote JAVA_OPTS !!!
+### reference: https://github.com/koalaman/shellcheck/wiki/SC2086
+java -classpath "${ZTS_CLASSPATH}" ${JAVA_OPTS} ${ZTS_BOOTSTRAP_CLASS} < /dev/null &
+PID=$!
+
+sleep 2;
+if ! kill -0 "${PID}" > /dev/null 2>&1; then
+    exit 1
+fi
+
+force_shutdown() {
+    echo 'Will forcefully stopping ZTS...'
+    kill -9 ${PID} >/dev/null 2>&1
+    echo 'Forcefully stopped ZTS success'
+    exit 1
+}
+shutdown() {
+    if [ -z ${PID} ]; then
+        echo 'ZTS is not running'
+        exit 1
+    else
+        if ! kill -0 ${PID} > /dev/null 2>&1; then
+            echo 'ZTS is not running'
+            exit 1
+        else
+            # start shutdown
+            echo 'Will stopping ZTS...'
+            kill ${PID}
+
+            # wait for shutdown
+            count=0
+            while [ -d "/proc/${PID}" ]; do
+                echo 'Shutdown is in progress... Please wait...'
+                sleep 1
+                count="$((count + 1))"
+    
+                if [ "${count}" = "${ZTS_STOP_TIMEOUT}" ]; then
+                    break
+                fi
+            done
+            if [ "${count}" != "${ZTS_STOP_TIMEOUT}" ]; then
+                echo 'Shutdown completed.'
+            fi
+
+            # if not success, force shutdown
+            if kill -0 ${PID} > /dev/null 2>&1; then
+                force_shutdown
+            fi
+        fi
+    fi
+
+    # confirm ZTS stopped
+    if ! kill -0 ${PID} > /dev/null 2>&1; then
+        exit 0
+    fi
+}
+
+# SIGINT
+trap shutdown 2
+
+# SIGTERM
+trap shutdown 15
+
+# wait
+wait ${PID}


### PR DESCRIPTION
## Issue

1. The current entry point using a shell process to resolve ENV variables. However, it does not forward signal to the child JAVA process when `docker stop` executes, which causes the docker container to forcefully stop after timeout.
2. JAVA process returns exit code `143` (128+15) on receiving `SIGTERM` (15), which consider as fail termination in K8s.

## Fixes

1. forward `SIGINT` and `SIGTERM` to the child JAVA process
2. ignore JAVA's exit code, add logic to determine exit code (0 or 1) in the entry point script.
3. extra
    - change default ENV value for paths to absolute path
    - athenz root pom.xml updated, regenerate the `docker/util/athenz-mvn-base/Dockerfile` file.

## Concern

1. If passwords or other ENV variables contains space in its value, the docker will fail to start.
   - https://github.com/WindzCUHK/athenz/blob/b3722e16358f217f33a1445425114dbf3fd0e666/docker/zms/docker-entrypoint.sh#L10-L18